### PR TITLE
Iter2 reccs pt1

### DIFF
--- a/foodventures-express-app/routes/favorites.js
+++ b/foodventures-express-app/routes/favorites.js
@@ -54,10 +54,10 @@ router.post("/add_favorites", async (req, res) =>{
           (userCuisines[recipeCuisine] =1)
         }
         
-        {userIngs[highestWeight.food] ? 
-          (userIngs[highestWeight.food] +=1) 
+        {userIngs[highestWeight.food.toLowerCase()] ? 
+          (userIngs[highestWeight.food.toLowerCase()] +=1) 
           : 
-          (userIngs[highestWeight.food] =1)
+          (userIngs[highestWeight.food.toLowerCase()] =1)
         }
         console.log(JSON.stringify(highestWeight) + " hi");
         console.log(highestWeight.food + " ho");
@@ -100,10 +100,10 @@ router.delete("/remove_favorites", async (req, res) =>{
           : 
           (userCuisines[recipeCuisine] -=1)
         }
-        {userIngs[highestWeight.food] === 1 ? 
-          (delete userIngs[highestWeight.food]) 
+        {userIngs[highestWeight.food.toLowerCase()] === 1 ? 
+          (delete userIngs[highestWeight.food.toLowerCase()]) 
           : 
-          (userIngs[highestWeight.food] -=1)
+          (userIngs[highestWeight.food.toLowerCase()] -=1)
         }
 
         const updatedCount = await User.update(

--- a/foodventures-ui-app/constant.js
+++ b/foodventures-ui-app/constant.js
@@ -3,7 +3,7 @@ export const API_ID = "305eeabe";
 export const API_KEY = "9e7c1459f48822c0c067d0077d3d3962";
 export const API_CALL = `https://api.edamam.com/api/recipes/v2`
 
-export function url(recipeId = null, cuisine = null, q = null){
+export function url({recipeId = null, cuisine = null, q = null}){
 
   const linkBack = `?type=public&app_id=${API_ID}&app_key=${API_KEY}&random=true`
   let generalLink = API_CALL+linkBack;

--- a/foodventures-ui-app/src/components/RecipeInfo/RecipeInfo.jsx
+++ b/foodventures-ui-app/src/components/RecipeInfo/RecipeInfo.jsx
@@ -98,7 +98,7 @@ export default function RecipeInfo() {
   const apiCall = async () => {
     console.log(recipeId);
     const response = await fetch(
-      url(recipeId, null, null)
+      url({recipeId})
     );
     const data = await response.json();
     setRecipe(data.recipe);

--- a/foodventures-ui-app/src/components/SearchResults/SearchResults.jsx
+++ b/foodventures-ui-app/src/components/SearchResults/SearchResults.jsx
@@ -10,8 +10,8 @@ export default function SearchResults({cuisine, search, updateSearch}) {
   const [currRecipes, updateRecipes] = useState([]);
 
   const apiCall = async () =>{
-      console.log(url(null, cuisine, search));
-      const response = await fetch(url(null, cuisine, search));
+      console.log(url({cuisine, q: search}));
+      const response = await fetch(url({cuisine, q: search}));
       const data = await response.json();
       updateRecipes(data.hits);
   };

--- a/foodventures-ui-app/src/components/User/Profile/Profile.jsx
+++ b/foodventures-ui-app/src/components/User/Profile/Profile.jsx
@@ -39,7 +39,9 @@ export default function Profile() {
     const data = await response.json();
     console.log(data.topCuisines)
     setCuisines(data.topCuisines);
-    setCuisinesFetched(true);
+    if(data.topCuisines.length > 0){
+      setCuisinesFetched(true);
+    }
   };
   
   const topIngs = async () => {
@@ -53,24 +55,24 @@ export default function Profile() {
     const data = await response.json();
     console.log(data.topIngs);
     setIngredients(data.topIngs);
-    setIngredientsFetched(true);
+    if(data.topIngs.length > 0){
+      setIngredientsFetched(true);
+    }
   };
   
 
   const showReccs = async () =>{
     let possibleReccs = [];
     const checkIngs = new Set(ingredients);
-    // for loop to fetch recipes from differen cuisines and concats them to an array, where i can hold 60 recipes (important for random cuisine pull)
     for(let i = 0; i < cuisines.length; i++){
       const responseCuisine = await fetch(url({cuisine: cuisines[i]}));
-      //console.log(ingredients[i]);
-      //const responseIngs = await fetch(url({q: ingredients[i]}));
       const dataCuisine = await responseCuisine.json();
-      //const dataIngs = await responseIngs.json();
       possibleReccs = possibleReccs.concat(dataCuisine.hits);
-      //possibleReccs = possibleReccs.concat(dataIngs.hits);
+
     }
+    
     let reccs = [];
+    console.log(checkIngs);
     let takenIdx = new Set();
     console.log(possibleReccs);
     possibleReccs.forEach((option, index) => {
@@ -81,14 +83,7 @@ export default function Profile() {
         }
       })
     })
-    //randomly select 8 recipes from my pool of recipes
-    /*
-    for(let i = takenIdx.size ; i < 8; i++){
-      reccs.push(possibleReccs[Math.floor(Math.random()*possibleReccs.length)]);
-    }
 
-   */
-    console.log(reccs);
     while(takenIdx.size < 8){
       const idx = Math.floor(Math.random()*possibleReccs.length);
       if(!takenIdx.has(idx)){

--- a/foodventures-ui-app/src/components/User/Profile/Profile.jsx
+++ b/foodventures-ui-app/src/components/User/Profile/Profile.jsx
@@ -59,22 +59,46 @@ export default function Profile() {
 
   const showReccs = async () =>{
     let possibleReccs = [];
+    const checkIngs = new Set(ingredients);
     // for loop to fetch recipes from differen cuisines and concats them to an array, where i can hold 60 recipes (important for random cuisine pull)
     for(let i = 0; i < cuisines.length; i++){
       const responseCuisine = await fetch(url({cuisine: cuisines[i]}));
-      console.log(ingredients[i]);
-      const responseIngs = await fetch(url({q: ingredients[i]}));
+      //console.log(ingredients[i]);
+      //const responseIngs = await fetch(url({q: ingredients[i]}));
       const dataCuisine = await responseCuisine.json();
-      const dataIngs = await responseIngs.json();
+      //const dataIngs = await responseIngs.json();
       possibleReccs = possibleReccs.concat(dataCuisine.hits);
-      possibleReccs = possibleReccs.concat(dataIngs.hits);
+      //possibleReccs = possibleReccs.concat(dataIngs.hits);
     }
     let reccs = [];
+    let takenIdx = new Set();
+    console.log(possibleReccs);
+    possibleReccs.forEach((option, index) => {
+      option.recipe.ingredients.forEach((ing) => {
+        if(checkIngs.has(ing.food)){
+          reccs.push(option);
+          takenIdx.add(index);
+        }
+      })
+    })
     //randomly select 8 recipes from my pool of recipes
-    for(let i = 0; i < 8; i++){
+    /*
+    for(let i = takenIdx.size ; i < 8; i++){
       reccs.push(possibleReccs[Math.floor(Math.random()*possibleReccs.length)]);
     }
-    console.log(reccs)
+
+   */
+    console.log(reccs);
+    while(takenIdx.size < 8){
+      const idx = Math.floor(Math.random()*possibleReccs.length);
+      if(!takenIdx.has(idx)){
+        reccs.push(possibleReccs[idx]);
+        takenIdx.add(idx)
+      }
+    }
+     
+    console.log(reccs);
+    console.log(takenIdx);
     setReccs(reccs);
     setIsLoading(false);
   }

--- a/foodventures-ui-app/src/components/User/Profile/Profile.jsx
+++ b/foodventures-ui-app/src/components/User/Profile/Profile.jsx
@@ -70,20 +70,20 @@ export default function Profile() {
       possibleReccs = possibleReccs.concat(dataCuisine.hits);
 
     }
-    
+    // check each recipes ingredients to see if users fave ings are included
+    // sacrifice performance for accuracy 
     let reccs = [];
     console.log(checkIngs);
     let takenIdx = new Set();
-    console.log(possibleReccs);
     possibleReccs.forEach((option, index) => {
       option.recipe.ingredients.forEach((ing) => {
-        if(checkIngs.has(ing.food)){
+        if(checkIngs.has(ing.food.toLowerCase())){
           reccs.push(option);
           takenIdx.add(index);
         }
       })
     })
-
+    // avoids repeating recipes
     while(takenIdx.size < 8){
       const idx = Math.floor(Math.random()*possibleReccs.length);
       if(!takenIdx.has(idx)){
@@ -91,8 +91,6 @@ export default function Profile() {
         takenIdx.add(idx)
       }
     }
-     
-    console.log(reccs);
     console.log(takenIdx);
     setReccs(reccs);
     setIsLoading(false);

--- a/foodventures-ui-app/src/components/User/Profile/Profile.jsx
+++ b/foodventures-ui-app/src/components/User/Profile/Profile.jsx
@@ -3,6 +3,7 @@ import { UserContext } from "../../UserContext.js";
 import { Link } from 'react-router-dom';
 import "./Profile.css";
 import {API_ID, API_KEY} from "../../../../constant.js";
+import { url } from "../../../../constant.js";
 
 export default function Profile() {
   const { currUser } = useContext(UserContext);
@@ -57,13 +58,12 @@ export default function Profile() {
   
 
   const showReccs = async () =>{
-    let url = `https://api.edamam.com/api/recipes/v2?type=public&app_id=${API_ID}&app_key=${API_KEY}`;
     let possibleReccs = [];
     // for loop to fetch recipes from differen cuisines and concats them to an array, where i can hold 60 recipes (important for random cuisine pull)
     for(let i = 0; i < cuisines.length; i++){
-      const responseCuisine = await fetch(url+`&cuisineType=${cuisines[i]}`);
+      const responseCuisine = await fetch(url({cuisine: cuisines[i]}));
       console.log(ingredients[i]);
-      const responseIngs = await fetch(url+`&q=${ingredients[i]}`);
+      const responseIngs = await fetch(url({q: ingredients[i]}));
       const dataCuisine = await responseCuisine.json();
       const dataIngs = await responseIngs.json();
       possibleReccs = possibleReccs.concat(dataCuisine.hits);


### PR DESCRIPTION
### Description
pt1 of the optimization for rects
- Instead of making 6 total external api calls for 1 recomendation (3 for cuisine, 3 for ings), make only 3 for cuisine
  - With the smaller pool, locate recipes within the pool that contain any of the top 3 ingredients and prioritize their addition into the recc 
- Avoid duplicate recommendations by tracking indices taken at any given time
- Standardize ingredient names by changing to one casing so i don't skip potential candidates (avoid ignoring 'Shrimp' if one of the fav ingredients is 'shrimp')
- **Cons**:
  -  Looking for if ingredients in a recipe appear in the users favorite ings sacrifices time
- **Pros**:
  - More Personalized Results for the user
  - Reduce api calls in one recommendation search by half 
### Milestone
- pt 1 of iter2
- plan on adding the caching and a "generate new reccs" button after caching