### PR TITLE
Global Recipe Storage

### DIFF
--- a/foodventures-express-app/models/recipe.js
+++ b/foodventures-express-app/models/recipe.js
@@ -18,7 +18,7 @@ export const Recipe = sequelize.define('Recipe', {
   },
   cuisine: {
     type: DataTypes.STRING,
-    allowNull: false,
+    allowNull: true,
   },
   recipe :{
     type: DataTypes.JSONB,
@@ -26,6 +26,10 @@ export const Recipe = sequelize.define('Recipe', {
   },
   difficulty :{
     type: DataTypes.JSONB,
+    allowNull: true
+  },
+  scrape :{
+    type: DataTypes.ARRAY(DataTypes.STRING),
     allowNull: true
   }
 });

--- a/foodventures-express-app/models/recipe.js
+++ b/foodventures-express-app/models/recipe.js
@@ -10,7 +10,7 @@ export const Recipe = sequelize.define('Recipe', {
   },
   userId: {
     type: DataTypes.INTEGER,
-    allowNull: false
+    allowNull: true
   },
   recipeId: {
     type: DataTypes.STRING,
@@ -23,6 +23,10 @@ export const Recipe = sequelize.define('Recipe', {
   recipe :{
     type: DataTypes.JSONB,
     allowNull: false
+  },
+  difficulty :{
+    type: DataTypes.JSONB,
+    allowNull: true
   }
 });
 

--- a/foodventures-express-app/routes/recipe.js
+++ b/foodventures-express-app/routes/recipe.js
@@ -65,4 +65,39 @@ router.get("/get_recipe", async (req, res) => {
   }
 });
 
+router.post("/store_recipe_info", async (req,res) =>{
+  const {
+    recipeId,
+    cuisine,
+    difficulty,
+    recipe
+    } = req.body;
+  try{
+    const newRecipeStored = await Recipe.create(
+      {
+        recipeId: recipeId,
+        cuisine: cuisine,
+        recipe: recipe,
+        difficulty: difficulty
+      }
+    );
+    res.status(200).json(recipe)
+  }
+  catch(error){
+    res.status(500).json({error: "Server Error: " + error});
+  }
+})
+
+router.delete("/remove_recipe_info", async (req, res) => {
+  const {recipeId} = req.body;
+  try{
+    const favorite = await Recipe.findOne({ where: { userId: null, recipeId: recipeId} });
+    await favorite.destroy();
+    res.status(200).json({res: "destroyed"})
+  }
+  catch(error){
+    res.status(500).json({error: "Server Error: " + error});
+  }
+})
+
 export default router;

--- a/foodventures-express-app/routes/recipe.js
+++ b/foodventures-express-app/routes/recipe.js
@@ -70,7 +70,8 @@ router.post("/store_recipe_info", async (req,res) =>{
     recipeId,
     cuisine,
     difficulty,
-    recipe
+    recipe,
+    scrape
     } = req.body;
   try{
     const newRecipeStored = await Recipe.create(
@@ -78,7 +79,8 @@ router.post("/store_recipe_info", async (req,res) =>{
         recipeId: recipeId,
         cuisine: cuisine,
         recipe: recipe,
-        difficulty: difficulty
+        difficulty: difficulty,
+        scrape: scrape
       }
     );
     

--- a/foodventures-express-app/routes/recipe.js
+++ b/foodventures-express-app/routes/recipe.js
@@ -81,9 +81,11 @@ router.post("/store_recipe_info", async (req,res) =>{
         difficulty: difficulty
       }
     );
+    
     res.status(200).json(recipe)
   }
   catch(error){
+    console.error(error);
     res.status(500).json({error: "Server Error: " + error});
   }
 })
@@ -96,6 +98,7 @@ router.delete("/remove_recipe_info", async (req, res) => {
     res.status(200).json({res: "destroyed"})
   }
   catch(error){
+    console.error(error);
     res.status(500).json({error: "Server Error: " + error});
   }
 })

--- a/foodventures-ui-app/src/components/RecipeInfo/RecipeInfo.jsx
+++ b/foodventures-ui-app/src/components/RecipeInfo/RecipeInfo.jsx
@@ -163,26 +163,33 @@ export default function RecipeInfo() {
       console.log(isRecipeInDb);
       if(!isRecipeInDb){
         await storeRecipeInfo();
-        const cacheTimeout = setTimeout(() => {removeRecipeFromDB()}, 60000);
+        const cacheTimeout = setTimeout(() => {removeRecipeFromDB()}, 300000);
       }
     }
   };
 
-  useEffect(() => {
-    /*const inCache = localStorage.getItem(`searched/${recipeId}`)
-    console.log(inCache)
-    if(inCache){
-      const cachedInfo = JSON.parse(inCache);
-      setRecipe(cachedInfo.recipe);
-      findMainIngredients(cachedInfo.recipe);
-      setRecipeScrape(cachedInfo.recipeScrape);
+  const displayStoredRecipe = async () => {
+    console.log("im in");
+    const confirmingRecipeExistance = await checkIfRecipeStored();
+    console.log(confirmingRecipeExistance);
+    if(confirmingRecipeExistance !== null){
+      setRecipe(confirmingRecipeExistance.recipe);
+      findMainIngredients(confirmingRecipeExistance.recipe);
+      setRecipeScrape(confirmingRecipeExistance.scrape);
       setRecipeFetched(true);
       setIsScraped(true);
-      setUrlSupported(cachedInfo.recipeScrape.length > 1);
-      setDifficulty(cachedInfo.difficulty);
-    }*/
-    apiCall();
+      setUrlSupported(confirmingRecipeExistance.scrape.length > 1);
+      setDifficulty(confirmingRecipeExistance.difficulty);
+      setDifficultyCalculated(true);
+    }
+    else{
+      apiCall();
+    }
     checkInFavs();
+  };
+
+  useEffect(() => {
+    displayStoredRecipe();
   }, [recipeId]);
 
   useEffect(() =>{
@@ -197,16 +204,6 @@ export default function RecipeInfo() {
   }, [recipeFetched, isScraped]);
 
   useEffect(() =>{
-    /*if(recipeFetched && isScraped && difficulty){
-      setLoadStatus(false);
-      const cachedInfo = {
-        recipe,
-        recipeScrape,
-        difficulty
-      };
-      localStorage.setItem(`searched/${recipeId}`, JSON.stringify(cachedInfo));
-      const cacheTimeout = setTimeout(() => {localStorage.removeItem(`searched/${recipeId}`);}, 60000);
-    }*/
     executeStorage();
   }, [recipeFetched, isScraped, difficultyCalculated]);
 

--- a/foodventures-ui-app/src/components/RecipeInfo/RecipeInfo.jsx
+++ b/foodventures-ui-app/src/components/RecipeInfo/RecipeInfo.jsx
@@ -119,9 +119,9 @@ export default function RecipeInfo() {
       },
       body: JSON.stringify({
         recipeId: recipeId,
-        cuisine: "hello",
         difficulty: difficulty,
-        recipe: recipe
+        recipe: recipe,
+        scrape: recipeScrape
       })
     });
     const recipeInfo= await storeRecipe.json();
@@ -159,9 +159,9 @@ export default function RecipeInfo() {
   const executeStorage = async () => {
     if(recipeFetched && isScraped && difficultyCalculated){
       setLoadStatus(false);
-      const checkingExistanceOfRewcipe = await checkIfRecipeStored();
-      console.log(checkingExistanceOfRewcipe);
-      if(!checkingExistanceOfRewcipe){
+      const isRecipeInDb = await checkIfRecipeStored();
+      console.log(isRecipeInDb);
+      if(!isRecipeInDb){
         await storeRecipeInfo();
         const cacheTimeout = setTimeout(() => {removeRecipeFromDB()}, 60000);
       }


### PR DESCRIPTION
### Description
- 'Caching' of recipe info like difficulty ranking and scrape applied on a global level:
  - Before used localStorage to persist recipe information which would be unavailable to multiple users
  - switched approach to using db table for storing the same information and pulling it if available for all users. An example might make things clearer:
    1) Let's say I am logged in and I look up a specific cheeseburger recipe. If it is not already present in the db, I set a new row for the recipe. 
    2) If I visit a different route and go back to the cheeseburger, recipe info persist instead of loading the information. 
    3) If I sign out of my account and log in to Swapnil's account, and navigate to the same cheeseburger recipe, near no loading time is necessary for information to persist. 
    4) If I sign out completely and no user is logged in, navigate to cheeseburger recipe, near no loading time is required 

### Milestone
TC Stretch goal

### Demo

https://github.com/MetaU-Capstone/Capstone/assets/93235490/05b22f31-dfd4-4a29-a0e9-27ae27b270be

